### PR TITLE
Update contacts for Government Digital Service (alphagov)

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -457,9 +457,14 @@
             "url": "https://gov.uk/",
             "gitHubOrganization": "alphagov",
             "contact1": {
-                "name": "Terence Eden",
-                "email": "terence.eden@digital.cabinet-office.gov.uk",
-                "gitHubID": "edent"
+                "name": "James O'Neill",
+                "email": "james.oneill@digital.cabinet-office.gov.uk",
+                "gitHubID": "jameseoneill"
+            },
+            "contact2": {
+                "name": "Matt Hobbs",
+                "email": "matthew.hobbs@digital.cabinet-office.gov.uk",
+                "gitHubID": "Nooshu"
             }
         },
         "signature": {

--- a/entities.json
+++ b/entities.json
@@ -454,7 +454,7 @@
         "info": {
             "name": "Government Digital Service (on behalf of Cabinet Office)",
             "address": "7th Floor, The White Chapel Building,, 10 Whitechapel High Street,",
-            "url": "https://gov.uk/",
+            "url": "https://www.gov.uk/government/organisations/government-digital-service",
             "gitHubOrganization": "alphagov",
             "contact1": {
                 "name": "James O'Neill",


### PR DESCRIPTION
Terence Eden (@edent) is on secondment to NHSX. Update the contacts for the Government Digital Service (alphagov) to James O'Neill, Head of Open Standards (@jameseoneill) and Matt Hobbs, Head of Frontend (@Nooshu).

I've also updated the URL as our organisation page on GOV.UK seems like a better entry point than the GOV.UK homepage.

Closes #10