### PR TITLE
Remove my own, invalid signature

### DIFF
--- a/individuals.json
+++ b/individuals.json
@@ -5365,18 +5365,6 @@
         }
     },
     {
-        "id": "c9c563f0-5952-42e7-bb6b-001660e93ed6",
-        "verified": false,
-        "workstreams": "all",
-        "info": {
-            "name": "Psychpsyo",
-            "gitHubID": "psychpsyo"
-        },
-        "signature": {
-            "signedAt": "2024-11-19T21:14:42.474Z"
-        }
-    },
-    {
         "id": "42c104f0-3a08-471d-b706-6f561f7629fa",
         "verified": true,
         "workstreams": "all",


### PR DESCRIPTION
Removing this because it has a typo in my github name, and I think I also put some of the private info in incorrectly.
(It is currently hogging my email, so I can't just re-sign with the correct info)