### PR TITLE
Update data for Canrong Lan

### DIFF
--- a/individuals.json
+++ b/individuals.json
@@ -5810,7 +5810,7 @@
         "workstreams": "all",
         "info": {
             "name": "Canrong Lan",
-            "gitHubID": "chanran"
+            "gitHubID": "Chanran"
         },
         "signature": {
             "signedAt": "2025-09-16T14:43:43.142Z"


### PR DESCRIPTION
github id first character may be uppercase because https://github.com/whatwg/html/pull/11668 pr status is not updated though clicked the [sync github pr status button](https://participate.whatwg.org/agreement-status?user=Chanran&repo=html&pull=11668)

<img width="1772" height="532" alt="image" src="https://github.com/user-attachments/assets/c36d382e-7c0d-43f5-9c9b-c1da904fa85f" />


<img width="1804" height="850" alt="image" src="https://github.com/user-attachments/assets/551ad704-3eaf-4c98-9765-1da28c7b7652" />
